### PR TITLE
repository transfer and improve security, file and error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/kazeburo/rotatewriter
+module github.com/monitoring-forge/rotatewriter
 
-go 1.25.0
+go 1.25

--- a/rotatewriter.go
+++ b/rotatewriter.go
@@ -95,12 +95,12 @@ func (w *RotateWriter) openFile() error {
 		return err
 	}
 
-	file, err := os.OpenFile(w.Filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	file, err := openFile(w.Filename)
 	if err != nil {
 		return err
 	}
 
-	fi, err = file.Stat()
+	fi, err := file.Stat()
 	if err != nil {
 		file.Close()
 		return err
@@ -115,9 +115,7 @@ func (w *RotateWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.file == nil {
-		if err := w.openFile(); err != nil {
-			return 0, err
-		}
+		return 0, fmt.Errorf("file is not open")
 	}
 	if w.currentSize+int64(len(p)) >= int64(w.MaxSize*1024*1024) {
 		if err := w.rotate(); err != nil {

--- a/rotatewriter.go
+++ b/rotatewriter.go
@@ -1,6 +1,7 @@
 package rotatewriter
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -92,6 +93,10 @@ func (w *RotateWriter) openFile() (*os.File, error) {
 			return nil, err
 		}
 	}
+	// File is symlinke. it's should be error
+	if fi, err := os.Lstat(w.Filename); err == nil && fi.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("file is a symlink: %s", w.Filename)
+	}
 	return os.OpenFile(w.Filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 }
 
@@ -113,7 +118,10 @@ func (w *RotateWriter) Write(p []byte) (int, error) {
 
 func (w *RotateWriter) rotate() error {
 	if err := w.file.Close(); err != nil {
-		return err
+		// ignore error if file is already closed
+		if !errors.Is(err, os.ErrClosed) {
+			return err
+		}
 	}
 
 	currentLog := filepath.Join(w.dir, fmt.Sprintf("%s%s", w.basename, w.ext))

--- a/rotatewriter.go
+++ b/rotatewriter.go
@@ -93,9 +93,14 @@ func (w *RotateWriter) openFile() (*os.File, error) {
 			return nil, err
 		}
 	}
-	// File is symlinke. it's should be error
-	if fi, err := os.Lstat(w.Filename); err == nil && fi.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("file is a symlink: %s", w.Filename)
+	// Return an error if the target path is a symlink.
+	fi, err := os.Lstat(w.Filename)
+	if err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("file is a symlink: %s", w.Filename)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
 	}
 	return os.OpenFile(w.Filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 }

--- a/rotatewriter.go
+++ b/rotatewriter.go
@@ -102,7 +102,9 @@ func (w *RotateWriter) openFile() error {
 
 	fi, err := file.Stat()
 	if err != nil {
-		file.Close()
+		if cerr := file.Close(); cerr != nil {
+			return fmt.Errorf("stat failed: %w (close failed: %v)", err, cerr)
+		}
 		return err
 	}
 

--- a/rotatewriter.go
+++ b/rotatewriter.go
@@ -1,7 +1,6 @@
 package rotatewriter
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -74,35 +73,45 @@ func New(ops ...WriterOption) (*RotateWriter, error) {
 	w.ext = filepath.Ext(w.Filename)
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	file, err := w.openFile()
+	err := w.openFile()
 	if err != nil {
 		return nil, err
 	}
-	w.file = file
-	fi, err := file.Stat()
-	if err != nil {
-		return nil, err
-	}
-	w.currentSize = fi.Size()
 	return w, nil
 }
 
-func (w *RotateWriter) openFile() (*os.File, error) {
+func (w *RotateWriter) openFile() error {
 	if w.AutoDirCreate {
 		if err := os.MkdirAll(w.dir, 0755); err != nil {
-			return nil, err
+			return err
 		}
 	}
 	// File is symlinke. it's should be error
 	if fi, err := os.Lstat(w.Filename); err == nil && fi.Mode()&os.ModeSymlink != 0 {
-		return nil, fmt.Errorf("file is a symlink: %s", w.Filename)
+		return fmt.Errorf("file is a symlink: %s", w.Filename)
 	}
-	return os.OpenFile(w.Filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	file, err := os.OpenFile(w.Filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+	fi, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return err
+	}
+	w.file = file
+	w.currentSize = fi.Size()
+	return nil
 }
 
 func (w *RotateWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.file == nil {
+		if err := w.openFile(); err != nil {
+			return 0, err
+		}
+	}
 	if w.currentSize+int64(len(p)) >= int64(w.MaxSize*1024*1024) {
 		if err := w.rotate(); err != nil {
 			return 0, err
@@ -118,10 +127,9 @@ func (w *RotateWriter) Write(p []byte) (int, error) {
 
 func (w *RotateWriter) rotate() error {
 	if err := w.file.Close(); err != nil {
-		// ignore error if file is already closed
-		if !errors.Is(err, os.ErrClosed) {
-			return err
-		}
+		w.file = nil
+		w.currentSize = 0
+		return err
 	}
 
 	currentLog := filepath.Join(w.dir, fmt.Sprintf("%s%s", w.basename, w.ext))
@@ -162,12 +170,9 @@ func (w *RotateWriter) rotate() error {
 		}
 	}
 
-	file, err := w.openFile()
-	if err != nil {
+	if err := w.openFile(); err != nil {
 		return err
 	}
-	w.file = file
-	w.currentSize = 0
 	return nil
 }
 
@@ -175,7 +180,10 @@ func (w *RotateWriter) Close() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if w.file != nil {
-		return w.file.Close()
+		err := w.file.Close()
+		w.file = nil
+		w.currentSize = 0
+		return err
 	}
 	return nil
 }

--- a/rotatewriter.go
+++ b/rotatewriter.go
@@ -86,20 +86,18 @@ func (w *RotateWriter) openFile() error {
 			return err
 		}
 	}
-	file, err := os.OpenFile(w.Filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
-	if err != nil {
+	// Return an error if the target path is a symlink.
+	if fi, err := os.Lstat(w.Filename); err == nil {
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("file is a symlink: %s", w.Filename)
+		}
+	} else if !os.IsNotExist(err) {
 		return err
 	}
 
-	// Return an error if the target path is a symlink.
-	fi, err := os.Lstat(w.Filename)
+	file, err := os.OpenFile(w.Filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
-		file.Close()
 		return err
-	}
-	if fi.Mode()&os.ModeSymlink != 0 {
-		file.Close()
-		return fmt.Errorf("file is a symlink: %s", w.Filename)
 	}
 
 	fi, err = file.Stat()
@@ -140,7 +138,8 @@ func (w *RotateWriter) rotate() error {
 		w.currentSize = 0
 		return err
 	}
-
+	w.file = nil
+	w.currentSize = 0
 	currentLog := filepath.Join(w.dir, fmt.Sprintf("%s%s", w.basename, w.ext))
 	backupLog := filepath.Join(w.dir, fmt.Sprintf("%s-%d%s", w.basename, time.Now().UnixNano(), w.ext))
 	if err := os.Rename(currentLog, backupLog); err != nil {

--- a/rotatewriter.go
+++ b/rotatewriter.go
@@ -1,7 +1,6 @@
 package rotatewriter
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -87,24 +86,28 @@ func (w *RotateWriter) openFile() error {
 			return err
 		}
 	}
-	// Return an error if the target path is a symlink.
-	fi, err := os.Lstat(w.Filename)
-	if err == nil {
-		if fi.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("file is a symlink: %s", w.Filename)
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
 	file, err := os.OpenFile(w.Filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 	if err != nil {
 		return err
 	}
+
+	// Return an error if the target path is a symlink.
+	fi, err := os.Lstat(w.Filename)
+	if err != nil {
+		file.Close()
+		return err
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		file.Close()
+		return fmt.Errorf("file is a symlink: %s", w.Filename)
+	}
+
 	fi, err = file.Stat()
 	if err != nil {
 		file.Close()
 		return err
 	}
+
 	w.file = file
 	w.currentSize = fi.Size()
 	return nil

--- a/rotatewriter_test.go
+++ b/rotatewriter_test.go
@@ -85,3 +85,22 @@ func TestRotateWriter_AutoDirCreate(t *testing.T) {
 		t.Errorf("directory not created: %v", err)
 	}
 }
+
+func TestRotateWriter_SymlinkError(t *testing.T) {
+	dir := t.TempDir()
+	filename := filepath.Join(dir, "test.log")
+	// Create a symlink
+	symlinkPath := filepath.Join(dir, "symlink.log")
+	if err := os.Symlink(filename, symlinkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+	_, err := New(Filename(symlinkPath), MaxSize(1), MaxBackups(1), AutoDirCreate(true))
+	if err == nil {
+		t.Fatal("expected error when creating RotateWriter with symlink, got nil")
+	}
+
+	_, err = New(Filename(filename), MaxSize(1), MaxBackups(1), AutoDirCreate(true))
+	if err != nil {
+		t.Fatalf("failed to create RotateWriter with regular file: %v", err)
+	}
+}

--- a/rotatewriter_test.go
+++ b/rotatewriter_test.go
@@ -95,12 +95,13 @@ func TestRotateWriter_SymlinkError(t *testing.T) {
 		t.Skipf("skipping: unable to create symlink on this platform (or due to permissions): %v", err)
 	}
 	_, err := New(Filename(symlinkPath), MaxSize(1), MaxBackups(1), AutoDirCreate(true))
-	if err == nil {
-		t.Fatal("expected error when creating RotateWriter with symlink, got nil")
+	if err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("expected symlink error when creating RotateWriter with symlink, got: %v", err)
 	}
 
-	_, err = New(Filename(filename), MaxSize(1), MaxBackups(1), AutoDirCreate(true))
+	w, err := New(Filename(filename), MaxSize(1), MaxBackups(1), AutoDirCreate(true))
 	if err != nil {
 		t.Fatalf("failed to create RotateWriter with regular file: %v", err)
 	}
+	defer w.Close()
 }

--- a/rotatewriter_test.go
+++ b/rotatewriter_test.go
@@ -92,7 +92,7 @@ func TestRotateWriter_SymlinkError(t *testing.T) {
 	// Create a symlink
 	symlinkPath := filepath.Join(dir, "symlink.log")
 	if err := os.Symlink(filename, symlinkPath); err != nil {
-		t.Fatalf("failed to create symlink: %v", err)
+		t.Skipf("skipping: unable to create symlink on this platform (or due to permissions): %v", err)
 	}
 	_, err := New(Filename(symlinkPath), MaxSize(1), MaxBackups(1), AutoDirCreate(true))
 	if err == nil {

--- a/rotatewriter_unix.go
+++ b/rotatewriter_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+// +build !windows
+
+package rotatewriter
+
+import (
+	"os"
+	"syscall"
+)
+
+func openFile(filename string) (*os.File, error) {
+	return os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND|syscall.O_NOFOLLOW, 0644)
+}

--- a/rotatewriter_windows.go
+++ b/rotatewriter_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+// +build windows
+
+package rotatewriter
+
+import (
+	"os"
+)
+
+func openFile(filename string) (*os.File, error) {
+	return os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+}


### PR DESCRIPTION
This pull request introduces several improvements to the `rotatewriter` package, focusing on enhanced security, better error handling, and improved test coverage. The main changes include preventing the use of symlinks for log files, platform-specific file opening logic, and more robust resource management.

**Security and file handling improvements:**

* The writer now explicitly rejects symlink targets for log files, returning an error if the specified file is a symlink. This prevents potential security issues related to symlink attacks.
* The file opening logic is now platform-specific: on Unix systems, files are opened with the `O_NOFOLLOW` flag to prevent following symlinks, while Windows uses the standard flags. This is implemented in `rotatewriter_unix.go` and `rotatewriter_windows.go`. [[1]](diffhunk://#diff-1ee0ec474f3ef87b0d676fa0069a57d70c2403608f37538c80987ae24ae6a35fR1-R13) [[2]](diffhunk://#diff-f3cb5d8f5d7f0e27f43cca17ffbc67060766d85479b226e46578c7e5e24649fcR1-R12)

**Error handling and resource management:**

* Refactored file opening and rotation logic to ensure that the writer's state (`file`, `currentSize`) is properly reset on errors and after file closure, improving robustness and preventing resource leaks. [[1]](diffhunk://#diff-0d5d61bfb3039e01d7412500ac2b408f5431b33492d62cb17085ac5a957b46bbL76-R121) [[2]](diffhunk://#diff-0d5d61bfb3039e01d7412500ac2b408f5431b33492d62cb17085ac5a957b46bbR137-R142) [[3]](diffhunk://#diff-0d5d61bfb3039e01d7412500ac2b408f5431b33492d62cb17085ac5a957b46bbL157-R194)

**Testing improvements:**

* Added a test (`TestRotateWriter_SymlinkError`) to verify that creating a writer with a symlink as the target file returns the expected error, ensuring this security feature is properly enforced.

**Other changes:**

* Updated the module path in `go.mod` to reflect the new repository location.